### PR TITLE
Fix a bug in setpixel: bitshift unsigned long rather than int.

### DIFF
--- a/potrace/_potrace.pyx
+++ b/potrace/_potrace.pyx
@@ -355,9 +355,9 @@ cdef void setpixel(potrace_bitmap_s *bmp, int x, int y, int on):
     Set a pixel on or off in a potrace_bitmap_s.
     """
     if on:
-        bmp.map[y*bmp.dy + x/N] |= 1 << (N - 1 - x % N)
+        bmp.map[y*bmp.dy + x/N] |=  (1uL << (N - 1 - x % N))
     else:
-        bmp.map[y*bmp.dy + x/N] &= ~(1 << (N - 1 - x % N))
+        bmp.map[y*bmp.dy + x/N] &= ~(1uL << (N - 1 - x % N))
 
 
 cdef State state_from_ptr(potrace_state_s *state):


### PR DESCRIPTION
Hi, thanks for creating this great wrapper around libpotrace!

I found a bug when I used pypotrace on my system.  The result of pypotrace (plotted using matplotlib) looked like this:
http://postimage.org/image/6w8uzfiit/
when it should have looked like this:
http://postimage.org/image/5sntkqn4n/

I spent 2 days tracking it down: verifying that I was using pypotrace correctly; comparing the incorrect pypotrace result to the output from the potrace command-line program (which was correct); and tracing through the potrace, libpotrace and pypotrace code in detail.

Eventually I realised that the incorrect corner segments always started & ended on multiples of 64 pixels:
http://postimage.org/image/z6y98a4qt/

This indicated that the contours of the binary image were being switched on/off into rectangular blocks by pypotrace before calling the potrace_trace function.  So I suspected the setpixel function, specifically some sort of integer sign problem.

When I changed the bitshifted int 1 to an unsigned long 1uL in setpixel, it fixed the bug.
